### PR TITLE
Assembler Update

### DIFF
--- a/boneless/arch/asm.py
+++ b/boneless/arch/asm.py
@@ -1,12 +1,13 @@
 import re
 
 from . import mc
+from . import opcode
 
-
-__all__ = ["TranslationError", "assemble", "disassemble"]
+__all__ = ["TranslationError", "Assembler", "assemble", "disassemble"]
 
 
 class TranslationError(Exception):
+    " Fail on no translation "
     def __init__(self, message, *args, lines=False, **locs):
         super().__init__(message, *args)
         self.lines = lines
@@ -24,222 +25,314 @@ class TranslationError(Exception):
                 for loc, indexes in self.locs.items()
             })
 
+class Assembler:
+    """
+    Assembler of Boneless code
+    """
 
-def parse_text(input, *, instr_cls):
-    output = []
-    for index, line in enumerate(str(input).splitlines()):
-        m = re.match(r"""
-            ^\s*
-            (?: (?P<label>[a-z][a-z0-9]*):\s*)?
-            (?:
-            |   (?P<instr>[a-z].*?)
-            |   (?P<direct>\.[a-z][a-z0-9]*)\s*(?P<args>.*?)
-            )\s*
-            (?: ;.*)?
-            \s*$
-        """, line, re.I|re.X)
-        line_output = []
-        if m["label"]:
-            line_output.append(mc.Label(m["label"]))
-        if m["instr"]:
-            try:
-                line_output.append(instr_cls.from_str(m["instr"]))
-            except ValueError as error:
-                while error.__cause__ is not None:
-                    error = error.__cause__
-                raise TranslationError(f"{{0}} at {{loc}}", error,
-                                       loc=(index,), lines=True) from None
-        if m["direct"]:
-            if m["direct"] == ".word":
-                line_output.append(int(m["args"], 0))
-            else:
-                raise TranslationError(f"Unknown directive {m['direct']} at {{loc}}",
-                                       loc=(index,), lines=True)
-        output.append(line_output)
-    return output
+    def __init__(self,instr_cls=opcode.Instr):
+        self.instr_cls = instr_cls
 
+        # convert text or take asm objects
+        self.input = []
 
-def emit_text(input, *, instr_cls):
-    output = []
-    for index, elem in enumerate(input):
-        if isinstance(elem, mc.Label):
-            output.append(f"{elem.name}:")
-        elif isinstance(elem, int):
-            output.append(f"\t.word\t{hex(elem)}")
-        elif isinstance(elem, instr_cls):
-            mnemonic = str(elem)
-            padding  = "\t" * max(0, 4 - len(mnemonic.expandtabs()) // 8)
-            try:
-                words = []
-                elem.encode(words)
-                encoding = " ".join("{:0{}X}".format(word, len(elem.coding) // 4)
-                                    for word in words)
-            except mc.UnresolvedRef:
-                encoding = "<reloc>"
-            output.append(f"\t{mnemonic}{padding}; {encoding}")
+        # array of encoded 16 bit integers
+        self.output = []
+
+        # mappings of assembly
+        self.constants = {}
+        self.const_locs = {}
+        self.label_addrs  = {}
+        self.label_locs = {}
+
+    def parse(self,input_d):
+        if isinstance(input_d,str):
+            self.parse_text(input_d)
         else:
-            raise TranslationError(f"Unrecognized value {repr(elem)} of type {elem_type_name} "
-                                   f"at {{loc}}", loc=(index,))
-    output.append("")
-    return "\n".join(output)
+            self.input.append(input_d)
 
-
-def assemble(input, *, instr_cls):
-    if isinstance(input, str):
-        input = parse_text(input, instr_cls=instr_cls)
-
-    label_locs  = {}
-    label_addrs = {}
-    instr_sizes = {}
-    fwd_adjust  = 0
-
-    def resolve(obj_addr, symbol):
-        # If the label isn't defined it could mean one of the two things:
-        #   * We're in the first relaxation pass.
-        #   * It's an external symbol.
-        # In both cases we return `None`, as a request to downstream code to lower to largest
-        # possible encoding.
-        if symbol in label_addrs:
-            result = label_addrs[symbol] - obj_addr
-            if result > 0:
-                # Each time we shrink a chunk, we need to move all labels after this chunk lower,
-                # or else relative forward offsets after this point may increase.
-                result -= fwd_adjust
-        else:
-            result = None
-        return result
-
-    def translate(elem, output, n_pass, *, indexes=(), allow_unresolved=None):
-        length = None
-        elem_addr = len(output)
-        if elem is None and n_pass == 1:
-            # `None` in input is OK during the first pass as a placeholder for a complex address
-            # computation that relies on a symbol that isn't defined yet; but after that it must
-            # be expanded, because we never return closures in the output.
-            output.append(None)
-        elif isinstance(elem, int):
-            output.append(elem)
-        elif isinstance(elem, list):
-            for index, nested_elem in enumerate(elem):
-                translate(nested_elem, output, n_pass,
-                          indexes=(*indexes, index), allow_unresolved=allow_unresolved)
-        elif isinstance(elem, mc.Label):
-            if n_pass == 1:
-                if elem.name in label_addrs:
-                    raise TranslationError(f"Label {repr(elem.name)} at {{new}} has the same name "
-                                           f"as the label at {{old}}",
-                                           new=indexes, old=label_locs[elem.name])
-                label_locs[elem.name] = indexes
-            label_addrs[elem.name] = elem_addr
-        elif isinstance(elem, instr_cls):
-            try:
-                # First, try encoding without relocation. This usually succeeds, and is faster.
-                length = elem.encode(output)
-            except mc.UnresolvedRef:
+    def parse_text(self,input_d):
+        for index, line in enumerate(str(input_d).splitlines()):
+            m = re.match(r"""
+                ^\s*
+                (?: (?P<label>[a-z][a-z0-9]*):\s*)?
+                (?:
+                |   (?P<instr>[a-z].*?)
+                |   (?P<direct>\.[a-z][a-z0-9]*)\s*(?P<args>.*?)
+                )\s*
+                (?: ;.*)?
+                \s*$
+            """, line, re.I|re.X)
+            line_output_d = []
+            if m["label"]:
+                line_output_d.append(mc.Label(m["label"]))
+            if m["instr"]:
                 try:
-                    # Compute the expected instruction size; necessary since offsets are computed
-                    # from address of the next instruction.
-                    length = instr_sizes.get(indexes, elem.max_length)
-                    # Second, relocate and try encoding again. This will always succeed if
-                    # the referenced label is defined, and will refine our size estimate.
-                    length = elem(lambda sym: resolve(elem_addr + length, sym)).encode(output)
-                except mc.UnresolvedRef as error:
-                    # If we still can't encode it...
-                    length = elem.max_length
-                    if allow_unresolved is None:
-                        # ... add a placeholder sized for the worst case during initial passes;
-                        for _ in range(length):
-                            output.append(None)
-                    elif allow_unresolved:
-                        # ... use the longest encoding if we're emitting relocations;
-                        rel_length = elem(lambda sym: 0).encode(output, use_longest=True)
-                        assert length == rel_length, f"Illegal longest encoding at {indexes}"
-                    else:
-                        # ... raise an error otherwise.
-                        raise TranslationError(f"{{0}} at {{loc}}", error,
-                                               loc=indexes) from None
-        elif hasattr(elem, "__call__"):
-            translate(elem(lambda sym: resolve(elem_addr, sym)), output, n_pass,
-                      indexes=indexes, allow_unresolved=allow_unresolved)
-            length = len(output) - elem_addr
+                    line_output_d.append(self.instr_cls.from_str(m["instr"]))
+                except ValueError as error:
+                    while error.__cause__ is not None:
+                        error = error.__cause__
+                    raise TranslationError(f"{{0}} at {{loc}}", error,
+                                           loc=(index,), lines=True) from None
+            if m["direct"]:
+                if m["direct"] == ".word":
+                    line_output_d.append(int(m["args"], 0))
+                else:
+                    raise TranslationError(f"Unknown directive {m['direct']} at {{loc}}",
+                                           loc=(index,), lines=True)
+            self.input.append(line_output_d)
+
+    def emit_text(self,input_d):
+        output = []
+        for index, elem in enumerate(input_d):
+            if isinstance(elem, mc.Label):
+                output.append(f"{elem.name}:")
+            elif isinstance(elem, int):
+                output.append(f"\t.word\t{hex(elem)}")
+            elif isinstance(elem,self.instr_cls):
+                mnemonic = str(elem)
+                padding  = "\t" * max(0, 4 - len(mnemonic.expandtabs()) // 8)
+                try:
+                    words = []
+                    elem.encode(words)
+                    encoding = " ".join("{:0{}X}".format(word, len(elem.coding) // 4)
+                                        for word in words)
+                except mc.UnresolvedRef:
+                    encoding = "<reloc>"
+                output.append(f"\t{mnemonic}{padding}; {encoding}")
+            else:
+                elem_type_name = f"{type(elem).__module__}.{type(elem).__qualname__}"
+                raise TranslationError(f"Unrecognized value {repr(elem)} of type {elem_type_name} "
+                                       f"at {{loc}}", loc=(index,))
+        output.append("")
+        return "\n".join(output)
+
+
+    def assemble(self):
+
+        label_locs  = {}
+        label_addrs = {}
+        instr_sizes = {}
+
+        constants = {}
+        const_locs = {}
+
+        fwd_adjust = 0
+
+        def resolve(obj_addr, symbol):
+            # If the label isn't defined it could mean one of the two things:
+            #   * We're in the first relaxation pass.
+            #   * It's an external symbol.
+            # In both cases we return `None`, as a request to downstream code to lower to largest
+            # possible encoding.
+            if symbol in label_addrs:
+                result = label_addrs[symbol] - obj_addr
+                if result > 0:
+                    # Each time we shrink a chunk, we need to move all labels after this chunk lower,
+                    # or else relative forward offsets after this point may increase.
+                    result -= fwd_adjust
+            elif symbol in constants:
+                result = constants[symbol]
+            else:
+                result = None
+
+            return result
+
+        def translate(elem, output_d, n_pass, *, indexes=(), allow_unresolved=None):
+            length = None
+            elem_addr = len(output_d)
+            # Process empty entries
+            if elem is None and n_pass == 1:
+                # `None` in input_d is OK during the first pass as a placeholder for a complex address
+                # computation that relies on a symbol that isn't defined yet; but after that it must
+                # be expanded, because we never return closures in the output_d.
+                output_d.append(None)
+            # Literal integer
+            elif isinstance(elem, int):
+                output_d.append(elem)
+            # Expand lists
+            elif isinstance(elem, list):
+                for index, nested_elem in enumerate(elem):
+                    translate(nested_elem, output_d, n_pass,
+                              indexes=(*indexes, index), allow_unresolved=allow_unresolved)
+            # Absolute references, insert for later
+            elif isinstance(elem,mc.AbsRef):
+                output_d.append(elem)
+            # Relative references, later
+            elif isinstance(elem,mc.RelRef):
+                output_d.append(elem)
+            # Constants, add to dict for translation
+            elif isinstance(elem, mc.Constant):
+                if n_pass == 1:
+                    if elem.name in self.constants:
+                        raise TranslationError(f"Const {repr(elem.name)} at {{new}} has the same name "
+                                               f"as the const at {{old}}",
+                                               new=indexes, old=str(const_locs[elem.name]))
+                    const_locs[elem.name] = indexes
+                constants[elem.name] = elem.value
+            # Label, add to dict
+            elif isinstance(elem, mc.Label):
+                if n_pass == 1:
+                    if elem.name in label_addrs:
+                        raise TranslationError(f"Label {repr(elem.name)} at {{new}} has the same name "
+                                               f"as the label at {{old}}",
+                                               new=indexes, old=label_locs[elem.name])
+                    label_locs[elem.name] = indexes
+                label_addrs[elem.name] = elem_addr
+            # It's an Instruction! , process
+            elif isinstance(elem, self.instr_cls):
+                try:
+                    # First, try encoding without relocation. This usually succeeds, and is faster.
+                    length = elem.encode(output_d)
+                except mc.UnresolvedRef:
+                    try:
+                        # Compute the expected instruction size; necessary since offsets are computed
+                        # from address of the next instruction.
+                        length = instr_sizes.get(indexes, elem.max_length)
+                        # Second, relocate and try encoding again. This will always succeed if
+                        # the referenced label is defined, and will refine our size estimate.
+                        length = elem(lambda sym: resolve(elem_addr + length, sym)).encode(output_d)
+                    except mc.UnresolvedRef as error:
+                        # If we still can't encode it...
+                        length = elem.max_length
+                        if allow_unresolved is None:
+                            # ... add a placeholder sized for the worst case during initial passes;
+                            for _ in range(length):
+                                output_d.append(None)
+                        elif allow_unresolved:
+                            # ... use the longest encoding if we're emitting relocations;
+                            rel_length = elem(lambda sym: 0).encode(output_d, use_longest=True)
+                            assert length == rel_length, f"Illegal longest encoding at {indexes}"
+                        else:
+                            # ... raise an error otherwise.
+                            raise TranslationError(f"{{0}} at {{loc}}", error,
+                                                   loc=indexes) from None
+            # can be Executed, call it and return the result
+            elif hasattr(elem, "__call__"):
+                translate(elem(lambda sym: resolve(elem_addr, sym)), output_d, n_pass,
+                          indexes=indexes, allow_unresolved=allow_unresolved)
+                length = len(output_d) - elem_addr
+            # it's not code, error out
+            else:
+                elem_type_name = f"{type(elem).__module__}.{type(elem).__qualname__}"
+                raise TranslationError(f"Unrecognized value {repr(elem)} of type {elem_type_name} "
+                                        f"at {{loc}}", loc=indexes)
+
+            # The assembler will terminate as long as two conditions are fulfilled:
+            #  1. The size of relocatable chunks never gets higher as the relative offsets shrink, and
+            #  2. The contents of relocatable chunks only depends on offsets.
+            # In other words, each relocatable chunk is a linear function of offsets. We can't easily
+            # check (2), but we can and do check (1) here as a precaution.
+            if length is not None:
+                old_length = instr_sizes.get(indexes, length)
+                assert length <= old_length, f"Expansion at {indexes}: {old_length} to {length}"
+                instr_sizes[indexes] = length
+                # Correct the offset in future forward relocations by accounting for backwards shift
+                # of labels caused by the instruction we may have just shrunk.
+                nonlocal fwd_adjust
+                fwd_adjust += old_length - length
+            return output_d
+
+        # Iterate to fixed point. This does more work than strictly necessary (if there are both
+        # forward and backward references, at least three iterations), but produces obviously correct
+        # result: if the (n-1)th and (n)th pass converged, then (n-1)th pass has updated every label
+        # to the same value as in (n)th pass, and (n)th pass has relocated every reference to
+        # the address of the label in either of them.
+        n_pass = 1
+        output_d = translate(self.input, [], n_pass)
+        while True:
+            fwd_adjust = 0
+            old_output_d = output_d
+            n_pass += 1
+            output_d = translate(self.input, [], n_pass)
+            if output_d == old_output_d:
+                break
+
+        # Convert absolute and relative references
+        for index, elem in enumerate(output_d):
+            if isinstance(elem,mc.Reference):
+                if elem.name not in label_addrs:
+                    raise TranslationError(f"Label {elem.name} does not exist at {index}")
+                if isinstance(elem, mc.RelRef):
+                    output_d[index] = label_addrs[elem.name]-index
+                if isinstance(elem, mc.AbsRef):
+                    output_d[index] = label_addrs[elem.name]
+
+        # If there are unresolved relocations, ensure they are either reported as an error or emitted
+        # as the longest possible encoding, for future linking.
+        if None in output_d:
+            fwd_adjust = 0
+            n_pass += 1
+            output_d = translate(self.input, [], n_pass, allow_unresolved=False)
+
+        # store the mapping
+        # constants, const_locs, labels, label_locs
+        self.constants = constants
+        self.const_locs = const_locs
+        self.label_addrs  = label_addrs
+        self.label_locs = label_locs
+
+        # store the output_d
+        self.output_d = output_d
+
+        return output_d
+
+    def info(self):
+        info_data = {
+            'constants' : self.constants,
+            'const_locs' : self.const_locs,
+            'label_addrs' : self.label_addrs,
+            'label_locs' : self.label_locs,
+        }
+        return info_data
+
+    def disassemble(self,input_d, labels=False, as_text=False):
+        index  = 0
+        output_d = []
+        addr_f = [0]
+        addr_r = {0: 0}
+        while index < len(input_d):
+            try:
+                instr, length = self.instr_cls.decode(input_d, index)
+                while instr.length != length:
+                    # This instruction is not well-behaved: it will not roundtrip to a sequence of
+                    # the same length, probably because it uses a noncanonical prefix form. Truncate
+                    # the instruction so that the prefix is decoded separately and try again.
+                    instr, length = self.instr_cls.decode(input_d[index:index + length - 1])
+                output_d.append(instr)
+                index += length
+            except ValueError:
+                output_d.append(input_d[index])
+                index += 1
+            addr_f.append(index)
+            addr_r[index] = len(output_d)
+
+        if labels:
+            labels_at = set()
+            for index, instr in enumerate(output_d):
+                if isinstance(instr, self.instr_cls):
+                    for op_name in instr.pc_rel_ops:
+                        label_at = addr_f[index + 1] + getattr(instr, op_name).value
+                        if label_at in range(addr_f[-1]):
+                            labels_at.add(label_at)
+                            setattr(instr, op_name, f"L{label_at}")
+            for label_at in reversed(sorted(labels_at)):
+                output_d.insert(addr_r[label_at], mc.Label(f"L{label_at}"))
+
+        if as_text:
+            return self.emit_text(output_d)
         else:
-            elem_type_name = f"{type(elem).__module__}.{type(elem).__qualname__}"
-            raise TranslationError(f"Unrecognized value {repr(elem)} of type {elem_type_name} "
-                                   f"at {{loc}}", loc=indexes)
-        # The assembler will terminate as long as two conditions are fulfilled:
-        #  1. The size of relocatable chunks never gets higher as the relative offsets shrink, and
-        #  2. The contents of relocatable chunks only depends on offsets.
-        # In other words, each relocatable chunk is a linear function of offsets. We can't easily
-        # check (2), but we can and do check (1) here as a precaution.
-        if length is not None:
-            old_length = instr_sizes.get(indexes, length)
-            assert length <= old_length, f"Expansion at {indexes}: {old_length} to {length}"
-            instr_sizes[indexes] = length
-            # Correct the offset in future forward relocations by accounting for backwards shift
-            # of labels caused by the instruction we may have just shrunk.
-            nonlocal fwd_adjust
-            fwd_adjust += old_length - length
-        return output
+            return output_d
 
-    # Iterate to fixed point. This does more work than strictly necessary (if there are both
-    # forward and backward references, at least three iterations), but produces obviously correct
-    # result: if the (n-1)th and (n)th pass converged, then (n-1)th pass has updated every label
-    # to the same value as in (n)th pass, and (n)th pass has relocated every reference to
-    # the address of the label in either of them.
-    n_pass = 1
-    output = translate(input, [], n_pass)
-    while True:
-        fwd_adjust = 0
-        old_output = output
-        n_pass += 1
-        output = translate(input, [], n_pass)
-        if output == old_output:
-            break
-
-    # If there are unresolved relocations, ensure they are either reported as an error or emitted
-    # as the longest possible encoding, for future linking.
-    if None in output:
-        fwd_adjust = 0
-        n_pass += 1
-        output = translate(input, [], n_pass, allow_unresolved=False)
-
+# helper functions
+def assemble(input_d,*,instr_cls):
+    asm = Assembler(instr_cls=instr_cls)
+    asm.parse(input_d)
+    output = asm.assemble()
     return output
 
+def disassemble(input_d,*,instr_cls,labels=None,as_text=False):
+    asm = Assembler(instr_cls=instr_cls)
+    output = asm.disassemble(input_d,labels=labels,as_text=as_text)
+    return output
 
-def disassemble(input, *, instr_cls, labels=False, as_text=False):
-    index  = 0
-    output = []
-    addr_f = [0]
-    addr_r = {0: 0}
-    while index < len(input):
-        try:
-            instr, length = instr_cls.decode(input, index)
-            while instr.length != length:
-                # This instruction is not well-behaved: it will not roundtrip to a sequence of
-                # the same length, probably because it uses a noncanonical prefix form. Truncate
-                # the instruction so that the prefix is decoded separately and try again.
-                instr, length = instr_cls.decode(input[index:index + length - 1])
-            output.append(instr)
-            index += length
-        except ValueError:
-            output.append(input[index])
-            index += 1
-        addr_f.append(index)
-        addr_r[index] = len(output)
-
-    if labels:
-        labels_at = set()
-        for index, instr in enumerate(output):
-            if isinstance(instr, instr_cls):
-                for op_name in instr.pc_rel_ops:
-                    label_at = addr_f[index + 1] + getattr(instr, op_name).value
-                    if label_at in range(addr_f[-1]):
-                        labels_at.add(label_at)
-                        setattr(instr, op_name, f"L{label_at}")
-        for label_at in reversed(sorted(labels_at)):
-            output.insert(addr_r[label_at], mc.Label(f"L{label_at}"))
-
-    if as_text:
-        return emit_text(output, instr_cls=instr_cls)
-    else:
-        return output

--- a/boneless/arch/asm.py
+++ b/boneless/arch/asm.py
@@ -252,7 +252,7 @@ class Assembler:
         for index, elem in enumerate(output_d):
             if isinstance(elem,mc.Reference):
                 if elem.name not in label_addrs:
-                    raise TranslationError(f"Label {elem.name} does not exist at {index}")
+                    raise TranslationError(f"Label {repr(elem.name)} does not exist at {index}")
                 if isinstance(elem, mc.RelRef):
                     output_d[index] = label_addrs[elem.name]-index
                 if isinstance(elem, mc.AbsRef):

--- a/boneless/arch/mc.py
+++ b/boneless/arch/mc.py
@@ -5,12 +5,53 @@ from parse import parse
 from string import Formatter
 
 
-__all__ = ["UnresolvedRef", "Label", "Operand", "Instr"]
+__all__ = ["UnresolvedRef", "Constant", "AbsRef", "RelRef", "Label", "Operand", "Instr"]
 
 
 class UnresolvedRef(Exception):
     pass
 
+
+class Constant:
+    __slots__ = ["name","value"]
+
+    def __init__(self, name,value):
+        self.name = name
+        self.value = value
+
+    def __repr__(self):
+        return f"Constant({self.name,self.value})"
+
+    def __eq__(self, other):
+        return isinstance(other, Constant) and self.name == other.name
+
+class Reference:
+    pass
+
+class AbsRef(Reference):
+    __slots__ = ["name"]
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"AbsRef({repr(self.name)})"
+
+    def __eq__(self, other):
+        return isinstance(other, AbsRef) and self.name == other.name
+
+
+class RelRef(Reference):
+    __slots__ = ["name"]
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"RelRef({repr(self.name)})"
+
+    def __eq__(self, other):
+        return isinstance(other, RelRef) and self.name == other.name
 
 class Label:
     __slots__ = ["name"]

--- a/boneless/arch/opcode.py
+++ b/boneless/arch/opcode.py
@@ -1,16 +1,16 @@
 from collections import defaultdict
 
-from .mc import Label
+from .mc import Label, Constant, RelRef, AbsRef
 from .instr import Instr, Reg
 
 
 __all__ = [
     # Directives
-    "L",
+    "L", "C", "RR", "AR",
     # Registers
     "R0",   "R1",   "R2",   "R3",   "R4",   "R5",   "R6",   "R7",
     # Instructions
-    "AND",  "ANDI", "OR",   "ORI",  "XOR",  "XORI", "CMP",  "CMPI",
+    "AND",  "ANDI", "OR",   "ORI",  "XOR",  "XORI", "CMP",  "CMPI", "NOT",
     "ADD",  "ADDI", "ADC",  "ADCI", "SUB",  "SUBI", "SBC",  "SBCI",
     "SLL",  "SLLI", "ROL",  "ROLI", "RORI", "SRL",  "SRLI", "SRA",  "SRAI",
     "LD",   "LDR",  "ST",   "STR",  "LDX",  "LDXA", "STX",  "STXA",
@@ -104,6 +104,9 @@ class C_EXT  (Instr): coding = "110-------------"
 
 # Directives
 L = Label
+C = Constant
+RR = RelRef
+AR = AbsRef
 
 # Registers
 R0, R1, R2, R3, R4, R5, R6, R7 = map(Reg, range(8))
@@ -206,3 +209,4 @@ def XCHG(Ra, Rb):
         return []
     else:
         return [XOR(Ra, Ra, Rb), XOR(Rb, Rb, Ra), XOR(Ra, Ra, Rb)]
+def NOT(Ra, Rb): return [XORI(Ra,Rb,0xFFFF)]

--- a/boneless/test/test_asm.py
+++ b/boneless/test/test_asm.py
@@ -128,7 +128,7 @@ class AssemblerTestCase(unittest.TestCase):
     def test_wrong_dup_label(self):
         self.assertTranslationError(
             [L("foo"), L("foo")],
-            r"Label 'foo' at indexes \[1\] has the same name as the label at indexes \[0\]")
+            r"Label 'foo' at indexes \[0\]\[1\] has the same name as the label at indexes \[0\]\[0\]")
 
     def test_wrong_unrecognized(self):
         self.assertTranslationError(

--- a/boneless/test/test_asm.py
+++ b/boneless/test/test_asm.py
@@ -42,6 +42,7 @@ class AssemblerTestCase(unittest.TestCase):
              0,
              int(J(-2))])
 
+
     def test_instr_rel_fwd(self):
         self.assertAssembles(
             [0,
@@ -124,6 +125,38 @@ class AssemblerTestCase(unittest.TestCase):
              int(ORI(R2,R3,123)),
              int(J(-1)),
              5678])
+
+    def test_constants(self):
+        self.assertAssembles(
+            [C('test',0xFF),
+            ADDI(R0,R0,'test')],
+            [int(ADDI(R0,R0,0xFF))]
+        )
+
+    def test_relative_ref_fail(self):
+        self.assertTranslationError(
+            [RR('fail')],
+            r"Label 'fail' does not exist at 0"
+        )
+
+    def test_relative_ref(self):
+        self.assertAssembles(
+            [L('test'),
+            [0] * 10,
+            RR('test'),
+            RR('test')],
+            [*[0] * 10, -10, -11]
+        )
+
+    def test_absolute_ref(self):
+        self.assertAssembles(
+            [[0] * 5,
+            L('test'),
+            [0] * 10,
+            AR('test'),
+            AR('test')],
+            [*[0] * 5 , *[0] * 10,5,5]
+        )
 
     def test_wrong_dup_label(self):
         self.assertTranslationError(

--- a/doc/manual/insns/NOT.tex
+++ b/doc/manual/insns/NOT.tex
@@ -1,0 +1,11 @@
+\begin{instruction}{NOT}{Logical NOT}
+  \assembly{\mnemonic{} Rd, Rs}
+  \purpose{To invert all the bits in a register.}
+  \restrictions{None.}
+\begin{remarks}
+The translates to a XORI with an 0xFFFF immediate 
+\begin{alltt}
+    XORI Rd, Rs, Rs
+\end{alltt}
+\end{remarks}
+\end{instruction}

--- a/doc/manual/insns/NOT.tex
+++ b/doc/manual/insns/NOT.tex
@@ -5,7 +5,7 @@
 \begin{remarks}
 The translates to a XORI with an 0xFFFF immediate 
 \begin{alltt}
-    XORI Rd, Rs, Rs
+    XORI Rd, Rs, 0xFFFF
 \end{alltt}
 \end{remarks}
 \end{instruction}

--- a/doc/manual/insns/index.tex
+++ b/doc/manual/insns/index.tex
@@ -174,6 +174,7 @@
 \input{MOVI.tex}
 \input{MOVR.tex}
 \input{NOP.tex}
+\input{NOT.tex} % pseudo
 \input{OR.tex}
 \input{ORI.tex}
 \input{ROL.tex}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -236,6 +236,9 @@ Bitwise OR between register and register/immediate.\\
 \makecell[l]{\tabinsn{XOR}{Rd, Ra, Rb} \\ \tabinsn{XORI}{Rd, Ra, imm}} & 
 Bitwise XOR between register and register/immediate.\\
 \hline
+\makecell[l]{\tabinsn{NOT}{Rd, Ra}} &
+Bitwise NOT between register and register.\\
+\hline
 \end{tabularx}
 
 \subsubsection{Shift \& Rotate}


### PR DESCRIPTION
Adds
 Constants
 Relative References
 Absolute Referneces
 Convert Assembler to an class for structural building
 NOT instruction and documentation

All existing tests run (with minor modifications for Assembler class)

TODO

Add tests for references, constants and NOT psuedo instruction.