### PR TITLE
Update LUT count comment in ALSRU

### DIFF
--- a/boneless/gateware/alsru.py
+++ b/boneless/gateware/alsru.py
@@ -35,7 +35,7 @@ class _OpWord(data.Struct):
 class ALSRU(wiring.Component):
     """ALSRU optimized for 4-LUT architecture with no adder pre-inversion.
 
-    On iCE40 with Yosys, ABC, and -relut this synthesizes to the optimal 4n+3 LUTs.
+    On iCE40 with Yosys, ABC, and -relut this synthesizes to the optimal 4n+2+ceil((n-1)/3) LUTs.
     """
 
     # The block diagram of an unit cell is as follows:


### PR DESCRIPTION
The number of LUTs necessary to compute the zero flag is relatively easy to predict, as the number of inputs a LUT tree can handle doesn't depend on the shape of the tree — an additional 4LUT always lets you handle 3 more inputs.

I haven't actually tested that Yosys+ABC achieves this, but since prjunnamed does, I'd be very surprised if ABC doesn't.